### PR TITLE
Configured queue max size item

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ sonicmq.connection_aggregate.messages.received_s[{#HOST},{#USER}] | Messages re
 Item Syntax | Description | Units |
 ----------- | ----------- | ----- |
 sonicmq.queue.discovery | Discover queues | Provides template variables {#NAME} {#BROKER} {#ID} |
+sonicmq.queue.max_size[{#BROKER},{#ID}] | Maximum queue size in kb  | |
 sonicmq.queue.max_age[{#BROKER},{#ID}] | Maximum message age in queue | |
 sonicmq.queue.size[{#BROKER},{#ID}] | Size of messages in queue | |
 sonicmq.queue.delivered_s[{#BROKER},{#ID}] | Messages delivered/s | |

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <target.dir>${project.build.directory}/SonicMqMonitor</target.dir>
         <sonicmq.version>8.5.1</sonicmq.version>
+        <xerces.version>2.9.1</xerces.version>
         <jackson.version>2.9.2</jackson.version>
         <java.version>1.7</java.version>
     </properties>
@@ -73,6 +74,11 @@
             <groupId>sonicmq</groupId>
             <artifactId>mgmt_config</artifactId>
             <version>${sonicmq.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>${xerces.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/digia/monitoring/sonicmq/IClientProxyFactory.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/IClientProxyFactory.java
@@ -12,10 +12,9 @@ public interface IClientProxyFactory {
 
     /**
      * Returns "global" domain level agent manager proxy.
-     * @param domain Domain
      * @return Agent manager proxy instance
      */
-    IAgentManagerProxy getDomainLevelAgentManagerProxy(String domain);
+    IAgentManagerProxy getDomainLevelAgentManagerProxy();
 
     /**
      * Returns broker proxy by broker's canonical (JMX) name.

--- a/src/main/java/com/digia/monitoring/sonicmq/cmd/SonicMQCollect.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/cmd/SonicMQCollect.java
@@ -51,6 +51,8 @@ public class SonicMQCollect {
             monitor.discoverQueues();
         	LOGGER.debug("Collecting discovered items...");
             monitor.collectDiscoveryItems(data);
+            LOGGER.debug("Collecting configuration items...");
+            monitor.collectConfigurationData(data);
         	LOGGER.debug("Collecting metrics data...");
             monitor.collectMetricsData(data);
         	LOGGER.debug("Collecting connection data...");

--- a/src/main/java/com/digia/monitoring/sonicmq/monitor/ClientProxyFactory.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/monitor/ClientProxyFactory.java
@@ -7,7 +7,6 @@ import java.util.Map;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.sql.CommonDataSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/digia/monitoring/sonicmq/monitor/ClientProxyFactory.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/monitor/ClientProxyFactory.java
@@ -1,20 +1,28 @@
 package com.digia.monitoring.sonicmq.monitor;
 
 import java.io.Closeable;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import javax.sql.CommonDataSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.digia.monitoring.sonicmq.IClientProxyFactory;
+import com.sonicsw.ma.mgmtapi.config.MgmtException;
 import com.sonicsw.mf.jmx.client.JMSConnectorAddress;
 import com.sonicsw.mf.jmx.client.JMSConnectorClient;
 import com.sonicsw.mf.mgmtapi.runtime.IAgentManagerProxy;
 import com.sonicsw.mf.mgmtapi.runtime.IAgentProxy;
 import com.sonicsw.mf.mgmtapi.runtime.MFProxyFactory;
+import com.sonicsw.mq.mgmtapi.config.IBrokerBean;
+import com.sonicsw.mq.mgmtapi.config.IQueuesBean;
+import com.sonicsw.mq.mgmtapi.config.MQMgmtBeanFactory;
+import com.sonicsw.mq.mgmtapi.config.IQueuesBean.IQueueAttributes;
 import com.sonicsw.mq.mgmtapi.runtime.IBrokerProxy;
 import com.sonicsw.mq.mgmtapi.runtime.MQProxyFactory;
 
@@ -37,53 +45,75 @@ class ClientProxyFactory implements Closeable, IClientProxyFactory {
     /** SonicMQ connector client. */
     private JMSConnectorClient client;
     
+    /** SonicMQ management bean factory. */
+    private MQMgmtBeanFactory mgmtBeanFactory;
+    
+    /** Map of broker beans, populated on demand. */
+    private Map<String, IBrokerBean> brokerBeans = new HashMap<>();
+    
+    /** Domain. */
+    private String domain;
+    
+    /** Location URL. */
+    private String location;
+    
+    /** Username. */
+    private String username;
+    
+    /** Password. */
+    private String password;
+    
     private Logger logger = LoggerFactory.getLogger(ClientProxyFactory.class);
 
     /**
      * Creates new ClientProxyFactory instance and connects to
+     * @param domain Domain
      * @param location Connection URL
      * @param username Username
      * @param password Password
      * @param timeout Connection timeout
      */
-    public ClientProxyFactory(String location, String username, String password, long timeout) {
+    public ClientProxyFactory(String domain, String location, String username, String password, long timeout) {
+        this.domain = domain;
+        this.location = location;
+        this.username = username;
+        this.password = password;
+        
         client = new JMSConnectorClient();
         Hashtable<String, String> env = new Hashtable<String, String>();
         env.put(CONNECTION_URLS, location);
         env.put(DEFAULT_USER, username);
         env.put(DEFAULT_PASSWORD, password);
-    	logger.debug("Connecting to {}", location);
+        logger.debug("Connecting to {}", location);
         client.connect(new JMSConnectorAddress(env), timeout);
     }
     
-    /* (non-Javadoc)
-     * @see com.digia.monitoring.sonicmq.monitor.IClientProxyFactory#getDomainLevelAgentManagerProxy(java.lang.String)
-     */
+    public IQueueAttributes getQueueAttributes(String broker, String queue) throws MgmtException {
+        IQueuesBean queuesBean = getBrokerBean(broker).getQueuesBean();
+        return queuesBean.getQueues().getQueue(queue);
+    }
+    
+    public IBrokerBean getBrokerBean(String broker) throws MgmtException {
+        populateBrokerBeans();
+        return brokerBeans.get(broker);
+    }
+    
     @Override
-    public IAgentManagerProxy getDomainLevelAgentManagerProxy(String domain) {
+    public IAgentManagerProxy getDomainLevelAgentManagerProxy() {
         String jmxName = domain + "." + IAgentManagerProxy.GLOBAL_ID + ":ID=" + IAgentManagerProxy.GLOBAL_ID;
         return getAgentManagerProxy(jmxName);
     }
-
-    /* (non-Javadoc)
-     * @see com.digia.monitoring.sonicmq.monitor.IClientProxyFactory#getBrokerProxy(java.lang.String)
-     */
+    
     @Override
     public IBrokerProxy getBrokerProxy(String jmxName) {
         return MQProxyFactory.createBrokerProxy(client, newObjectName(jmxName));
     }
     
-    /* (non-Javadoc)
-     * @see com.digia.monitoring.sonicmq.monitor.IClientProxyFactory#getAgentManagerProxy(java.lang.String)
-     */
     @Override
     public IAgentManagerProxy getAgentManagerProxy(String jmxName) {
         return MFProxyFactory.createAgentManagerProxy(client, newObjectName(jmxName));
     }
 
-    /* (non-Javadoc)
-     * @see com.digia.monitoring.sonicmq.monitor.IClientProxyFactory#getAgentProxy(java.lang.String)
-     */
     @Override
     public IAgentProxy getAgentProxy(String jmxName) {
         return MFProxyFactory.createAgentProxy(client, newObjectName(jmxName));
@@ -95,7 +125,26 @@ class ClientProxyFactory implements Closeable, IClientProxyFactory {
     public void close() {
         client.disconnect();
     }
+    
+    private void populateBrokerBeans() throws MgmtException {
+        // Bean name is not same as broker name, bean name includes folder structure
+        // So this creates lookup table that works with just broker name
+        MQMgmtBeanFactory factory = getMgmtBeanFactory();
+        for (Object beanName : factory.getBrokerBeanNames()) {
+            IBrokerBean bean = factory.getBrokerBean((String) beanName);
+            brokerBeans.put(bean.getBrokerName(), bean);
+        }
+    }
 
+    private MQMgmtBeanFactory getMgmtBeanFactory() throws MgmtException {
+        if (mgmtBeanFactory == null) {
+            MQMgmtBeanFactory factory = new MQMgmtBeanFactory();
+            factory.connect(domain, location, username, password);
+            this.mgmtBeanFactory = factory;
+        }
+        return mgmtBeanFactory;
+    }
+    
     /**
      * Creates JMX object name from string.
      * @param jmxName JMX name string

--- a/src/main/java/com/digia/monitoring/sonicmq/monitor/SonicMQMonitor.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/monitor/SonicMQMonitor.java
@@ -188,7 +188,7 @@ public class SonicMQMonitor implements Closeable {
                 
                 queueData.setData(QUEUE_CONFIG_MAX_SIZE, queueAttributes.getQueueMaxSize());
             } catch (MgmtException ex) {
-                // TODO
+                logger.warn("Could not retrieve configuration for queue " + queue.getName() + ".", ex);
             }
         }
     }

--- a/src/main/zabbix/etc/zabbix/zabbix_agentd.d/sonicmq-monitoring.conf
+++ b/src/main/zabbix/etc/zabbix/zabbix_agentd.d/sonicmq-monitoring.conf
@@ -60,6 +60,7 @@ UserParameter=sonicmq.connection_aggregate.messages.received[*],/etc/zabbix/scri
 UserParameter=sonicmq.connection_aggregate.messages.received_s[*],/etc/zabbix/scripts/sonicmq_connection_aggregate_item.sh "$1" "$2" connection.messages.ReceivedPerSecond
 
 # Queue items (script arguments: broker, queue, item)
+UserParameter=sonicmq.queue.max_size[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.config.QueueMaxSize
 UserParameter=sonicmq.queue.max_age[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.messages.MaxAge
 UserParameter=sonicmq.queue.size[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.messages.Size
 UserParameter=sonicmq.queue.delivered_s[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.messages.DeliveredPerSecond


### PR DESCRIPTION
- Added support for item reporting queue maximum size
- Added relevant Zabbix configuration
- Added methods to access configuration beans
- Added ugly dependency to old xercesImpl (necessary for post-1.6 JRE due to SonicMQ's dependency on implementation)