### PR TITLE
Clustered queue monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ sonicmq.connection_aggregate.messages.received[{#HOST},{#USER}] | Messages recei
 sonicmq.connection_aggregate.messages.received_s[{#HOST},{#USER}] | Messages received/s for all connections from host/user | |
 
 ### Queues ###
+Queue monitoring supports monitoring individual queues on each broker and monitoring of clustered queues for which stats are combined using appropriate aggregation operation.
+
 Item Syntax | Description | Units |
 ----------- | ----------- | ----- |
 sonicmq.queue.discovery | Discover queues | Provides template variables {#NAME} {#BROKER} {#ID} |
@@ -159,6 +161,14 @@ sonicmq.queue.count[{#BROKER},{#ID}] | Number of messages in queue | |
 sonicmq.queue.time_in_queue[{#BROKER},{#ID}] | Message time in queue | |
 sonicmq.queue.received_s[{#BROKER},{#ID}] | Messages received/s | |
 sonicmq.queue.max_depth[{#BROKER},{#ID}] | Queue maximum depth | |
+sonicmq.clustered.queue.discovery | Discover clustered queues | Provides template variables {#NAME} {#BROKER} {#ID} |
+sonicmq.clustered.queue.max_age[{#BROKER},{#ID}] | Maximum message age in clustered queue | |
+sonicmq.clustered.queue.size[{#BROKER},{#ID}] | Size of messages in clustered queue | |
+sonicmq.clustered.queue.delivered_s[{#BROKER},{#ID}] | Messages delivered/s | |
+sonicmq.clustered.queue.count[{#BROKER},{#ID}] | Number of messages in clustered queue | |
+sonicmq.clustered.queue.time_in_queue[{#BROKER},{#ID}] | Message time in clustered queue | |
+sonicmq.clustered.queue.received_s[{#BROKER},{#ID}] | Messages received/s | |
+sonicmq.clustered.queue.max_depth[{#BROKER},{#ID}] | Clustered queue maximum depth | |
 
 ### Topic Subscriptions ###
 

--- a/src/main/java/com/digia/monitoring/sonicmq/model/QueueDiscoveryItem.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/model/QueueDiscoveryItem.java
@@ -5,16 +5,38 @@ import static com.digia.monitoring.sonicmq.util.DigestUtil.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class QueueDiscoveryItem extends NamedDiscoveryItem {
-	
-	@JsonProperty("{#BROKER}")
-	private String broker;
-	
-	@JsonProperty("{#ID}")
-	private String id;
 
-	public QueueDiscoveryItem(String broker, String name) {
-		super(name);
-		this.broker = broker;
-		this.id = sha1hex(name);
-	}
+    @JsonProperty("{#BROKER}")
+    private String broker;
+
+    @JsonProperty("{#ID}")
+    private String id;
+    
+    @JsonProperty("{#CLUSTERED}")
+    private boolean clustered;
+
+    public QueueDiscoveryItem(String broker, String name, boolean clustered) {
+        super(name);
+        this.broker = broker;
+        this.id = sha1hex(name);
+        this.clustered = clustered;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj)) {
+            if (obj.getClass() == getClass()) {
+                String broker = ((QueueDiscoveryItem) obj).broker;
+                return this.broker != null ? this.broker.equals(broker) : broker == null;
+            }
+        }
+        
+        return false;
+    }
+    
+    @Override
+    public int hashCode() {
+        int hashCode = super.hashCode();
+        return broker != null ? hashCode + broker.hashCode() : hashCode;
+    }
 }

--- a/src/main/java/com/digia/monitoring/sonicmq/monitor/SonicMQMonitor.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/monitor/SonicMQMonitor.java
@@ -191,7 +191,7 @@ public class SonicMQMonitor implements Closeable {
         }
         for (SonicMQQueue queue : discoveredQueues) {
             data.addDiscoveryItem(DiscoveryItemClass.Queue,
-                    new QueueDiscoveryItem(queue.getBroker().getName(), queue.getName()));
+                    new QueueDiscoveryItem(queue.getBroker().getName(), queue.getName(), queue.isClustered()));
         }
         for (SonicMQSubscriber subscriber : discoveredSubscribers) {
             data.addDiscoveryItem(DiscoveryItemClass.TopicSubscription,

--- a/src/main/java/com/digia/monitoring/sonicmq/monitor/SonicMQQueue.java
+++ b/src/main/java/com/digia/monitoring/sonicmq/monitor/SonicMQQueue.java
@@ -12,6 +12,7 @@ public class SonicMQQueue {
     private SonicMQComponent broker;
     /** Queue name. */
     private String name;
+    private boolean clustered;
 
     /**
      * Creates new SonicMQQueue.
@@ -21,6 +22,7 @@ public class SonicMQQueue {
     public SonicMQQueue(SonicMQComponent broker, IQueueData queue) {
         this.broker = broker;
         this.name = queue.getQueueName();
+        this.clustered = queue.isClusteredQueue();
     }
 
     public SonicMQComponent getBroker() {
@@ -29,5 +31,9 @@ public class SonicMQQueue {
 
     public String getName() {
         return name;
+    }
+    
+    public boolean isClustered() {
+        return clustered;
     }
 }

--- a/src/main/zabbix/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh
+++ b/src/main/zabbix/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Version: 1.0
+
+set -e
+
+QUEUE=$1
+ITEM=$2
+AGGREGATE=$3
+
+cd $(dirname $0)
+
+# Load environment
+. ./sonicmq_env.sh
+
+function sonicmq_get_stat {
+  cat $SMQ_MON_OUTPUT_FILE | jq '[.data.Broker[].items.Queue["'$QUEUE'"].data["'$ITEM'"] // empty] | '$AGGREGATE
+}
+
+sonicmq_fetch_stat

--- a/src/main/zabbix/etc/zabbix/scripts/sonicmq_discovery.sh
+++ b/src/main/zabbix/etc/zabbix/scripts/sonicmq_discovery.sh
@@ -20,6 +20,9 @@ function sonicmq_get_stat {
   elif [ "$COMPONENT" = "TopicSubscriptionAggregate" ]; then
     AGGREGATED=$(cat $SMQ_MON_OUTPUT_FILE | jq '.discovery.TopicSubscription.data | map(del(.["{#BROKER}"])) | map(del(.["{#CONNECTIONID}"])) | unique // empty')
     echo '{ "data": '$AGGREGATED'}'
+  elif [ "$COMPONENT" = "ClusteredQueue" ]; then
+    AGGREGATED=$(cat $SMQ_MON_OUTPUT_FILE | jq '.discovery.Queue.data | map(select(.["{#CLUSTERED}"])) | map(del(.["{#BROKER}"])) | unique // empty')
+    echo '{ "data": '$AGGREGATED'}'
   else
     cat $SMQ_MON_OUTPUT_FILE | jq '.discovery.'$COMPONENT' // empty'
   fi

--- a/src/main/zabbix/etc/zabbix/zabbix_agentd.d/sonicmq-monitoring.conf
+++ b/src/main/zabbix/etc/zabbix/zabbix_agentd.d/sonicmq-monitoring.conf
@@ -5,6 +5,7 @@ UserParameter=sonicmq.agent_manager.discovery,/etc/zabbix/scripts/sonicmq_discov
 UserParameter=sonicmq.connection.discovery,/etc/zabbix/scripts/sonicmq_discovery.sh Connection
 UserParameter=sonicmq.connection_aggregate.discovery,/etc/zabbix/scripts/sonicmq_discovery ConnectionAggregate
 UserParameter=sonicmq.queue.discovery,/etc/zabbix/scripts/sonicmq_discovery.sh Queue
+UserParameter=sonicmq.clustered.queue.discovery,/etc/zabbix/scripts/sonicmq_discovery.sh ClusteredQueue
 UserParameter=sonicmq.errorqueue.discovery,/etc/zabbix/scripts/sonicmq_discovery.sh Queue
 UserParameter=sonicmq.topicsubscription.discovery,/etc/zabbix/scripts/sonicmq_discovery.sh TopicSubscription
 UserParameter=sonicmq.topicsubscription_aggregate.discovery,/etc/zabbix/scripts/sonicmq_discovery.sh TopicSubscriptionAggregate
@@ -71,6 +72,15 @@ UserParameter=sonicmq.errorqueue.count[*],/etc/zabbix/scripts/sonicmq_queue_item
 UserParameter=sonicmq.queue.time_in_queue[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.messages.TimeInQueue
 UserParameter=sonicmq.queue.received_s[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.messages.ReceivedPerSecond
 UserParameter=sonicmq.queue.max_depth[*],/etc/zabbix/scripts/sonicmq_queue_item.sh "$1" "$2" queue.messages.MaxDepth
+
+# Clustered queue items (script arguments: queue, item, aggregate)
+UserParameter=sonicmq.clustered.queue.max_age[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.MaxAge max
+UserParameter=sonicmq.clustered.queue.size[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.Size add
+UserParameter=sonicmq.clustered.queue.delivered_s[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.DeliveredPerSecond add
+UserParameter=sonicmq.clustered.queue.count[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.Count add
+UserParameter=sonicmq.clustered.queue.time_in_queue[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.TimeInQueue max
+UserParameter=sonicmq.clustered.queue.received_s[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.ReceivedPerSecond add
+UserParameter=sonicmq.clustered.queue.max_depth[*],/etc/zabbix/scripts/sonicmq_clustered_queue_item.sh "$1" queue.messages.MaxDepth max
 
 # Topic items (script arguments: broker, connection, topic, item)
 UserParameter=sonicmq.topicsubscription.message_count[*],/etc/zabbix/scripts/sonicmq_topicsubscription_item.sh "$1" "$2" "$3" topicSubscription.MessageCount


### PR DESCRIPTION
- Fixed bug which caused losing queues with same name in discovery
- Added clustered queue flag in discovery for identification
- Added clustered queue items