### PR TITLE
Upgrade vulnerable dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.digia.monitoring.sonicmq</groupId>
     <artifactId>zabbix-sonicmq-monitoring</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -14,7 +14,7 @@
         <target.dir>${project.build.directory}/SonicMqMonitor</target.dir>
         <sonicmq.version>8.5.1</sonicmq.version>
         <xerces.version>2.9.1</xerces.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.5</jackson.version>
         <java.version>1.7</java.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <target.dir>${project.build.directory}/SonicMqMonitor</target.dir>
         <sonicmq.version>8.5.1</sonicmq.version>
         <xerces.version>2.9.1</xerces.version>
-        <jackson.version>2.9.2</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
         <java.version>1.7</java.version>
     </properties>
 
@@ -28,6 +28,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- 2.9.2 jackson library had code injection vulnerability. Although unlikely to be triggered, upgraded to non-vulnerable version 2.9.4
